### PR TITLE
Fix to execute alias

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -10,6 +10,8 @@ alias d=docker
 alias dps='d ps'
 alias deit='d exec -it'
 alias dlogs='d logs'
+alias dimgs='d images'
+alias drminone='d rmi `dimgs -aq`'
 
 # Docker compose
 alias dc='d compose'
@@ -20,6 +22,5 @@ alias dcdown='dc down'
 alias dcstart='dc start'
 alias dcstop='dc stop'
 alias dcrestart='dc restart'
-alias drminone='d rmi `dimages -aq`'
 
 alias pbcopy='xsel --clipboard --input'


### PR DESCRIPTION
Fix `zsh: command not found: dimages`