### PR TITLE
Convert from exa to eza

### DIFF
--- a/.zsh/aliases.zsh
+++ b/.zsh/aliases.zsh
@@ -1,4 +1,4 @@
-alias ll="exa -l -h -@ -mU --icons --git --time-style=long-iso --color=automatic --group-directories-first"
+alias ll="eza -l -h -@ -mU --icons --git --time-style=long-iso --color=automatic --group-directories-first"
 alias l="ll -aa"
 
 # Git

--- a/.zshrc
+++ b/.zshrc
@@ -19,5 +19,13 @@ source "$SCRIPT_DIR/history.zsh"
 source "$SCRIPT_DIR/zinit.zsh"
 source "$HOME/local.zsh"
 
+# Init eza
+if type brew &>/dev/null; then
+  export FPATH="/home/linuxbrew/.linuxbrew/bin/eza/completions/zsh:$FPATH"
+  FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
+  autoload -Uz compinit
+  compinit
+fi
+
 # Init starship
 eval "$(starship init zsh)"


### PR DESCRIPTION
[exa](https://the.exa.website) is deprecated. So I use [eza](https://eza.rocks).