### PR TITLE
Change CI environment to ubuntu-slim and remove update step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,8 +95,8 @@ jobs:
 
   gatekeeper:
     name: Merge Gatekeeper
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    runs-on: ubuntu-slim
+    timeout-minutes: 2
     needs: [markdown-lint, test]
     if: ${{ !(failure() || contains(needs.*.result, 'cancelled')) }}
     steps:

--- a/dot_zprofile
+++ b/dot_zprofile
@@ -3,12 +3,3 @@
 # Homebrew
 ## Initialization
 eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-
-## Update packages
-brew update
-updateCheckCmd="brew outdated"
-if [[ -n $(eval "$updateCheckCmd") ]]; then
-  brew upgrade
-  brew autoremove
-  brew cleanup
-fi

--- a/dot_zsh/aliases.zsh
+++ b/dot_zsh/aliases.zsh
@@ -1,5 +1,10 @@
 # shellcheck disable=SC2148
 
+# updates
+alias brewu='brew update && brew upgrade && brew autoremove && brew cleanup'
+alias miseu='mise upgrade'
+alias updates='brewu && miseu'
+
 # eza
 alias ll="eza -l -h -@ -mU --icons --git --time-style=long-iso --color=automatic --group-directories-first"
 alias l="ll -aa"


### PR DESCRIPTION
Switch the CI environment from `ubuntu-latest` to `ubuntu-slim` for improved efficiency and remove the initial package update step to streamline the setup process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * CI/CDパイプラインのパフォーマンス最適化を実施しました。
  * シェル環境の自動更新メカニズムを再構成しました。
  * パッケージ管理用の新しいコマンドを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->