### PR TITLE
Add abbreviations for common git commands

### DIFF
--- a/dot_config/zabrze/config.yaml
+++ b/dot_config/zabrze/config.yaml
@@ -3,6 +3,16 @@ abbrevs:
   - name: git
     abbr: g
     snippet: git
+  - name: git fetch
+    abbr: f
+    snippet: fetch
+    context: '^git\s'
+    global: true
+  - name: git status
+    abbr: s
+    snippet: status
+    context: '^git\s'
+    global: true
   - name: git branch
     abbr: b
     snippet: branch
@@ -16,6 +26,31 @@ abbrevs:
   - name: git checkout
     abbr: ch
     snippet: checkout
+    context: '^git\s'
+    global: true
+  - name: git checkout -b
+    abbr: chb
+    snippet: checkout -b
+    context: '^git\s'
+    global: true
+  - name: git switch
+    abbr: sw
+    snippet: switch
+    context: '^git\s'
+    global: true
+  - name: git switch -c
+    abbr: swc
+    snippet: switch -c
+    context: '^git\s'
+    global: true
+  - name: git switch -t
+    abbr: swt
+    snippet: switch -t
+    context: '^git\s'
+    global: true
+  - name: git switch -
+    abbr: sw-
+    snippet: switch -
     context: '^git\s'
     global: true
   - name: git commit


### PR DESCRIPTION
Introduce new abbreviations for commands like `git fetch`, `git status`, and various `git switch` options to streamline command usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Git コマンドのショートカットを拡張しました。git fetch、git status、git checkout -b、git switch など、よく使うコマンドを短いエイリアスで実行できるようになり、コマンドライン操作がより効率的になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->